### PR TITLE
Table of Contents and navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ cd metamath-web
 cargo run ../set.mm/set.mm
 ```
 ### Viewing the pages
-Once the server is started, it will parse the metamath database. Wait until it displays the "Ready" message: it shall be a few seconds. You can then switch to a browser and visit [this URL](http://localhost:3030/mpeascii/mmset.raw.html) or for example [this URL](http://localhost:3030/mpeascii/o2p2e4) and start navigating. The port 3030 is the default, see usage for configuration of the server address and port.
+Once the server is started, it will parse the metamath database. Wait until it displays the "Ready" message: it shall be a few seconds. You can then switch to a browser and visit for example [http://localhost:3030/mpeascii/o2p2e4](http://localhost:3030/mpeascii/o2p2e4) or [the table of content](http://localhost:3030/mpeascii/toc) and start navigating. The port 3030 is the default, see usage for configuration of the server address and port.
 
 ### Stopping the server
 Just hit CTRL+C to stop the server once you're done browsing!
@@ -33,7 +33,7 @@ Here are some features implemented, and some which are still lacking:
 - [ ] in-line math in comments
 - [x] summary of the theorems (hypotheses and statement) before the proof
 - [ ] navigation to next/previous theorem in the database
-- [ ] table of content
+- [x] table of content
 - [ ] distinct variables
 - [ ] list of uses
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod statement;
+mod toc;
 #[cfg(feature = "sts")]
 mod sts;
 #[cfg(feature = "sts")]
@@ -12,6 +13,7 @@ use clap::ArgMatches;
 use metamath_knife::database::DbOptions;
 use metamath_knife::Database;
 use metamath_knife::diag::DiagnosticClass;
+use std::collections::HashMap;
 use std::convert::Infallible;
 use std::net::IpAddr;
 use std::path::Path;
@@ -93,6 +95,7 @@ fn build_db(args: &ArgMatches) -> Result<Database, String> {
     #[cfg(feature = "sts")]
     db.grammar_pass();
     db.stmt_parse_pass();
+    db.outline_pass();
     println!("Ready.");
     Ok(db)
 }
@@ -111,6 +114,14 @@ pub async fn get_theorem(explorer: String, label: String, renderer: Renderer) ->
     }
 }
 
+pub async fn get_toc(explorer: String, query: HashMap<String, String>, renderer: Renderer) -> Result<impl warp::Reply, Rejection> {
+    let chapter_ref : usize = query.get("ref").map_or(Ok(0), |c| c.parse()).unwrap_or(0);
+    match renderer.render_toc(explorer, chapter_ref) {
+        Some(html) => Ok(warp::reply::html(html)),
+        None => Err(warp::reject::not_found()),
+    }
+}
+
 #[tokio::main]
 async fn main() {
     let args = command_args();
@@ -123,18 +134,24 @@ async fn main() {
     let port : u16 = args.value_of("port").unwrap().parse().unwrap();
     match build_renderer(args) {
         Ok(renderer) => {
+            let toc_renderer = renderer.clone();
             let theorems = warp::path::param()
                 .and(warp::path::param())
                 .and(with_renderer(renderer))
-                .and_then(get_theorem)
-                .or(warp::path("static")
-                    .and(warp::fs::dir("static"))
-                    .map(|res: warp::fs::File|
-                        warp::reply::with_header(res, "cache-control", "public, max-age=31536000")
-                    )
-                )
-                .or(warp::fs::dir(path));
-            warp::serve(theorems).run((addr, port)).await;
+                .and_then(get_theorem);
+            let toc = warp::path::param()
+                .and(warp::path("toc"))
+                .and(warp::query::<HashMap<String, String>>())
+                .and(with_renderer(toc_renderer))
+                .and_then(get_toc);
+            let res = warp::path("static")
+                .and(warp::fs::dir("static"))
+                .map(|res: warp::fs::File|
+                    warp::reply::with_header(res, "cache-control", "public, max-age=31536000")
+                );
+            let statics = warp::fs::dir(path);
+            let routes = theorems.or(toc).or(res).or(statics);
+            warp::serve(routes).run((addr, port)).await;
         },
         Err(message) => {
             println!("Error: {}", message);

--- a/src/statement.hbs
+++ b/src/statement.hbs
@@ -9,12 +9,19 @@
 		{{header}}
 	</head>
 	<body>
+		<nav>
+			<ol class="breadcrumb">
+			{{#each breadcrumb}}
+				<li><a href="{{link}}" {{#if stmt_level}}class="label"{{/if}}>{{name}}</a></li>
+			{{/each}}
+			</ol>
+		</nav>
 		<h1><logo/>Metamath Proof Explorer</h1>
 		<hr />
 		<h2>{{statement_type}} <span class="label">{{label}}</span></h2>
 		<p><strong>Description:</strong> {{comment}}</p>
 
-		<div class="statement">
+		<section class="statement">
 			<table>
 				<tr>
 					<th class="col-step"></th>
@@ -37,12 +44,12 @@
 					<td class="col-expr">{{expr}}</td>
 				</tr>
 			</table>
-		</div>
+		</section>
 		<hr />
 
 		{{#if steps}}
-			<h3>{{#if is_proof}}Proof{{else}}Detailed syntax breakdown{{/if}}</h3>
-			<div class="proof">
+			<section class="proof">
+				<h3>{{#if is_proof}}Proof{{else}}Detailed syntax breakdown{{/if}}</h3>
 				<table>
 					<tr>
 						<th class="col-step">Step</th>

--- a/src/toc.hbs
+++ b/src/toc.hbs
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<link rel="shortcut icon" href="/static/favicon.ico" type="image/x-icon">
+		<link rel="stylesheet" href="/static/metamath.css">
+		<link rel="preconnect" href="https://fonts.googleapis.com">
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+		<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inconsolata:wght@200;500&family=Bitter:wght@200;500;700&display=swap">
+		{{header}}
+	</head>
+	<body>
+		<nav>
+			<ol class="breadcrumb">
+			{{#each breadcrumb}}
+				<li><a href="{{link}}" {{#if stmt_level}}class="label"{{/if}}>{{name}}</a></li>
+			{{/each}}
+			</ol>
+		</nav>
+		<h1><logo/>Metamath Proof Explorer</h1>
+		<hr />
+		<h2>Table of Contents - {{name}}</h2>
+		<ol class="toc">
+			{{#each children}}
+				<li><a href="{{link}}" {{#if stmt_level}}class="label"{{/if}}>{{name}}</a>
+					<ol>
+						{{#each children}}
+							<li><a href="{{link}}" {{#if stmt_level}}class="label"{{/if}}>{{name}}</a></li>
+						{{/each}}
+					</ol>
+				</li>
+			{{/each}}
+		</ol>
+    </body>
+</html>

--- a/src/toc.rs
+++ b/src/toc.rs
@@ -1,0 +1,87 @@
+use crate::statement::Renderer;
+use metamath_knife::outline::OutlineNodeRef;
+use metamath_knife::parser::HeadingLevel;
+use serde::Serializer;
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub(crate) struct TocInfo {
+    breadcrumb: Vec<ChapterInfo>,
+    name: String,
+    link: LinkInfo,
+    children: Vec<ChapterInfo>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct ChapterInfo {
+    name: String,
+    link: LinkInfo,
+    stmt_level: bool,
+    children: Vec<ChapterInfo>,
+}
+
+enum LinkInfo {
+    Toc,
+    ChapterRef(String),
+    StatementRef(String),
+}
+
+impl From<&OutlineNodeRef<'_>> for LinkInfo {
+    fn from(node: &OutlineNodeRef<'_>) -> Self { 
+        match node.get_level() {
+            HeadingLevel::Database => LinkInfo::Toc,
+            HeadingLevel::Statement => LinkInfo::StatementRef(node.get_name().to_string()),
+            _ => LinkInfo::ChapterRef(node.get_ref().to_string())
+        }
+    }
+}
+
+impl Serialize for LinkInfo {
+    fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error> where S: Serializer {
+        match self {
+            LinkInfo::Toc => serializer.serialize_str("toc"),
+            LinkInfo::StatementRef(name) => serializer.serialize_str(&name),
+            LinkInfo::ChapterRef(chapter_ref) => serializer.serialize_str(&format!("toc?ref={}", chapter_ref)),
+        }
+    }
+}
+
+pub(crate) fn get_breadcrumb(node: &OutlineNodeRef) -> Vec<ChapterInfo> {
+    node.ancestors_iter().map(|node| ChapterInfo {
+        name: node.get_name().to_string(),
+        stmt_level: node.get_level() == HeadingLevel::Statement,
+        link: (&node).into(),
+        children: vec![],
+    }).collect()
+}
+
+impl Renderer {
+    pub fn render_toc(&self, _explorer: String, chapter_ref: usize) -> Option<String> {
+        let node = if chapter_ref == 0 {
+            self.db.root_outline_node()
+        } else {
+            self.db.get_outline_node_by_ref(chapter_ref)
+        };
+        let info = TocInfo {
+            breadcrumb: get_breadcrumb(&node),
+            name: node.get_name().to_string(),
+            link: (&node).into(),
+            children: node.children_iter().map(|n| ChapterInfo {
+                name: n.get_name().to_string(),
+                link: (&n).into(),
+                stmt_level: n.get_level() == HeadingLevel::Statement,
+                children: n.children_iter().map(|c| ChapterInfo {
+                    name: c.get_name().to_string(),
+                    link: (&c).into(),
+                    stmt_level: c.get_level() == HeadingLevel::Statement,
+                    children: vec![],
+                }).collect()
+            }).collect(),
+        };
+        Some(
+            self.templates
+                .render("toc", &info)
+                .expect("Failed to render"),
+        )
+    }
+}

--- a/static/metamath.css
+++ b/static/metamath.css
@@ -7,7 +7,7 @@ body {
 }
 
 h1 {
-    margin: 50px 0px;
+    margin: 50px 0;
     font-weight: 700;
     background-image: url(/static/mmlogo.svg);
     background-repeat: no-repeat;
@@ -123,6 +123,37 @@ qed {
 
 qed::before {
     content: '\25A1';
+}
+
+nav {
+    margin-top: -50px;
+    float: right;
+}
+
+ol.breadcrumb li {
+    display: inline;
+}
+
+ol.breadcrumb {
+    display: flex;
+    flex-direction: row-reverse;
+    margin: 0 0 -30px 0;
+    padding-left: 0;
+    font-size: small;
+}
+
+ol.breadcrumb li:not(:last-child)::before {
+    content: "|";
+    color: #aab;
+    margin: 0 10px;
+}
+
+ol.breadcrumb a {
+    color: #aab;
+}
+
+ol.toc a, ol.breadcrumb a {
+    text-decoration: none;
 }
 
 mjx-container { margin: .3em 0em !important }


### PR DESCRIPTION
This adds new "Table of Contents" pages, for each chapter of the database, displaying the chapter contents with 2 levels of depth.
This also adds a breadcrumb at the top of all pages, allowing navigation to any parent chapter.
This branch depends on [PR#56 of metamath-knife](https://github.com/david-a-wheeler/metamath-knife/pull/56).

The following issues remain with this PR:
- chapter comments are not displayed (not yet parsed/stored by metamath-knife),
- chapter numbering is not yet done,
- the tree search algorithm to find the current position in the tree of chapters still has an issue.

Also, "next" and "previous" links, are still not yet implemented.